### PR TITLE
Run static checks on GitHub

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -26,4 +26,4 @@ jobs:
     - name: Check formatting of Python files
       run: ruff format --check
     - name: Check formatting of Bazel files
-      run: buildifier -mode=check -lint=warn -r .
+      run: buildifier -mode=check -lint=off -r .

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -33,7 +33,7 @@ jobs:
     # can be made available.
     # However, attempts to do this have failed so far.
     - name: Type checking with mypy
-      run: mypy --install-types compute/ test/
+      run: mypy --install-types --non-interactive compute/ test/
 
     - name: Type checking with pytype
       run: pytype compute/ test/

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -24,7 +24,7 @@ jobs:
     - run: pip install ruff mypy pytype
 
     - name: Check Bazel files
-      run: buildifier -mode=off -lint=warn -r .
+      run: buildifier -mode=check -lint=warn -r .
 
     - name: Check Python files
       run: ruff check

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,0 +1,39 @@
+name: Static checks
+
+on:
+  push:
+    branches: [ main, develop, test-github-actions ]
+  pull_request:
+    branches: [ main, develop, test-github-actions ]
+
+  workflow_dispatch:
+
+jobs:
+  static_checks:
+    # It probably is only necessary to run this on one operating system.
+    runs-on: ubuntu-22.04
+        
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup buildifier
+      uses: jbajic/setup-buildifier@v1
+      with:
+        version: 7.1.1
+
+    - run: pip install ruff mypy pytype
+
+    - name: Check Bazel files
+      run: buildifier -mode=off -lint=warn -r .
+
+    - name: Check Python files
+      run: ruff check
+
+    # Ideally type checking should be done under Bazel, so that all libraries
+    # can be made available.
+    # However, attempts to do this have failed so far.
+    - name: Type checking with mypy
+      run: mypy compute/ test/
+
+    - name: Type checking with pytype
+      run: pytype compute/ test/

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -33,7 +33,7 @@ jobs:
     # can be made available.
     # However, attempts to do this have failed so far.
     - name: Type checking with mypy
-      run: mypy compute/ test/
+      run: mypy --install-types compute/ test/
 
     - name: Type checking with pytype
       run: pytype compute/ test/


### PR DESCRIPTION
This runs a number of static checks:
* `buildifier` for Bazel files.
* `ruff` for Python.
* Two type checkers for Python: `mypy` and `pytype`. This may be excessive. There is also the problem that this does not give a good way of installing dependencies for type checking.